### PR TITLE
CIS-IP2 client reconnect, stream remainder, and get/set None semantics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,8 @@
 - `mypy` — type check
 - `pytest -q` — unit tests
 - `python -m build && twine check dist/*` — packaging check when metadata/build changes
+- Optional live smoke (not CI): `CISIP2_HOST=<ip> python tools/live_smoke.py`
+  (`CISIP2_SKIP_EXEC=1` for connect + get only)
 
 Run ruff, mypy, and pytest after code changes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and tag-based Publish workflow with Trusted Publishing.
 - Changelog, releasing docs, and agent/PR templates mirrored from sibling
   packaging practices.
+- Auto-reconnect with exponential backoff after unexpected TCP drops
+  (`RECONNECT_INITIAL_DELAY` / `RECONNECT_MAX_DELAY`); optional `on_reconnect`
+  hook scheduled after a successful reconnect.
+- `tools/live_smoke.py` for manual device smoke (`CISIP2_HOST`; not run in CI).
 
 ### Changed
 
 - Renamed import package from `sony_cispy` to `sony_cisip2`.
 - Requires Python 3.12+ (was marketed as 3.13+).
+- `get_feature` returns `None` on timeout, miss, NAK, or ERR (no
+  `"Unknown Value"` sentinel).
+- `set_feature` returns the device result string (`ACK` / `NAK` / `ERR`) or
+  `None` on timeout/miss (no `"Unknown Response"` sentinel).
+- `is_connected` reflects the connection flag only (no probe get).
+- JSON stream decode keeps an unparsed remainder across TCP reads.
+- Commands require an established connection (no lazy connect from send).
+
+### Fixed
+
+- Empty TCP read (EOF) and listener `OSError` mark the client disconnected and
+  fail pending command futures.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,8 @@
 - `mypy` — type check
 - `pytest -q` — unit tests
 - `python -m build && twine check dist/*` — packaging check when metadata/build changes
+- Optional live smoke (not CI): `CISIP2_HOST=<ip> python tools/live_smoke.py`
+  (`CISIP2_SKIP_EXEC=1` for connect + get only)
 
 Run ruff, mypy, and pytest after code changes.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ change before 1.0. See [CHANGELOG.md](CHANGELOG.md).
 - Universal `get_feature()` / `set_feature()` API for any CIS-IP2 feature
 - Command ID tracking with futures for reliable request/response matching
 - Real-time notification callbacks
-- JSON stream decoding for multi-message reads
+- JSON stream decoding with remainder across TCP read fragments
+- Auto-reconnect with exponential backoff after unexpected drops
 - Full command catalog via `commands_dict`
 - Stdlib only (no runtime dependencies)
 - Async/await (Python 3.12+)
@@ -67,8 +68,12 @@ from sony_cisip2 import SonyCISIP2
 async def main():
     async with SonyCISIP2(host="192.168.1.100") as client:
         power = await client.get_feature("main.power")
+        if power is None:
+            print("get main.power timed out or failed")
+            return
         print(f"Power: {power}")
-        await client.set_feature("main.volumestep", 50)
+        result = await client.set_feature("main.volumestep", 50)
+        print(f"set volume: {result}")
 
 asyncio.run(main())
 ```
@@ -91,6 +96,7 @@ sony-cispy/                 # GitHub repo root
 │   ├── constants.py
 │   └── variables.py
 ├── tests/
+├── tools/live_smoke.py     # Manual device smoke (CISIP2_HOST; not in CI)
 ├── reference/              # Historical sources (not shipped in the wheel)
 ├── example.py
 └── pyproject.toml
@@ -104,6 +110,13 @@ ruff check . && ruff format --check .
 mypy
 pytest -q
 python -m build && twine check dist/*
+```
+
+Optional live smoke against a device on your LAN (not run in CI):
+
+```bash
+CISIP2_HOST=<device-ip> CISIP2_SKIP_EXEC=1 python tools/live_smoke.py
+CISIP2_HOST=<device-ip> python tools/live_smoke.py
 ```
 
 Release process: [docs/releasing.md](docs/releasing.md).

--- a/example.py
+++ b/example.py
@@ -16,11 +16,11 @@ async def example_basic_usage():
         await client.connect()
         print("Connected!")
 
-        # Get power state
+        # Get power state (None on timeout / miss / NAK / ERR)
         power = await client.get_feature("main.power")
         print(f"Current power state: {power}")
 
-        # Set volume
+        # Set volume (ACK / NAK / ERR, or None on timeout)
         result = await client.set_feature("main.volumestep", 10)
         print(f"Set volume result: {result}")
 

--- a/src/sony_cisip2/README.md
+++ b/src/sony_cisip2/README.md
@@ -4,10 +4,10 @@ A modern Python library for controlling Sony Audio/Video Receivers (AVRs) and So
 
 ## Features
 
-- **Robust Connection Handling**: Command ID tracking with futures for reliable request/response matching
-- **Universal API**: Generic `get_feature()` and `set_feature()` methods that work with any CIS-IP2 feature
+- **Robust Connection Handling**: Command ID tracking with futures; auto-reconnect with backoff
+- **Universal API**: Generic `get_feature()` / `set_feature()` (return `None` on timeout/miss)
 - **Real-time Notifications**: Register callbacks to receive real-time updates when device state changes
-- **JSON Stream Decoding**: Handles multiple JSON messages arriving in a single read
+- **JSON Stream Decoding**: Multi-message reads with unparsed remainder across TCP fragments
 - **Timeout Handling**: Configurable timeouts for all network operations
 - **Command Discovery**: Access to the full CIS-IP2 command set via `commands_dict`
 - **Async/Await**: Built with modern Python async/await patterns
@@ -34,11 +34,11 @@ async def main():
     await client.connect()
     
     try:
-        # Get power state
+        # Get power state (None on timeout / miss / NAK / ERR)
         power = await client.get_feature("main.power")
         print(f"Power: {power}")
         
-        # Set volume
+        # Set volume (ACK / NAK / ERR, or None on timeout)
         result = await client.set_feature("main.volumestep", 50)
         print(f"Volume set: {result}")
         

--- a/src/sony_cisip2/client.py
+++ b/src/sony_cisip2/client.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable, Coroutine
 import contextlib
+import inspect
 import json
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from .constants import (
     CMD_ID_INITIAL,
@@ -17,11 +18,12 @@ from .constants import (
     MSG_TYPE_NOTIFY,
     MSG_TYPE_RESULT,
     MSG_TYPE_SET,
+    RECONNECT_INITIAL_DELAY,
+    RECONNECT_MAX_DELAY,
+    RESPONSE_ERR,
+    RESPONSE_NAK,
     TCP_TIMEOUT,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Awaitable
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,16 +31,14 @@ _LOGGER = logging.getLogger(__name__)
 class SonyCISIP2:
     """Client for Sony CIS-IP2 protocol communication.
 
-    This class provides a robust, modern implementation for controlling Sony
-    Audio/Video Receivers (AVRs) and Soundbars that support the CIS-IP2 protocol.
-
     Features:
-    - Command ID tracking with futures for reliable request/response matching
-    - JSON stream decoding for handling multiple messages in one read
-    - Timeout handling for all network operations
-    - Real-time notification callbacks
-    - Generic get_feature/set_feature API
-    - Automatic connection management
+    - Command ID tracking with futures for request/response matching
+    - JSON stream decoding with unparsed remainder across TCP reads
+    - Auto-reconnect with exponential backoff after unexpected drops
+      (``RECONNECT_INITIAL_DELAY`` → double → ``RECONNECT_MAX_DELAY``)
+    - Optional ``on_reconnect`` hook scheduled after a successful reconnect
+    - Notification callbacks; ``get_feature`` / ``set_feature`` return
+      ``None`` on timeout or miss (never sentinel strings)
     """
 
     def __init__(
@@ -46,6 +46,7 @@ class SonyCISIP2:
         host: str,
         port: int = DEFAULT_PORT,
         timeout: float = TCP_TIMEOUT,
+        on_reconnect: Callable[[], Coroutine[Any, Any, None]] | None = None,
     ) -> None:
         """Initialize the Sony CIS-IP2 client.
 
@@ -53,10 +54,15 @@ class SonyCISIP2:
             host: IP address of the Sony device
             port: TCP port (default: 33336)
             timeout: Timeout for network operations in seconds (default: 10.0)
+            on_reconnect: Optional async callback scheduled (not awaited inline)
+                after a successful automatic reconnect
         """
         self.host = host
         self.port = port
         self.timeout = timeout
+        self._on_reconnect: Callable[[], Coroutine[Any, Any, None]] | None = (
+            on_reconnect
+        )
 
         # Connection state
         self._reader: asyncio.StreamReader | None = None
@@ -72,14 +78,15 @@ class SonyCISIP2:
         # Notification callbacks
         self._notification_callbacks: dict[str | None, list[Callable]] = {}
 
-        # Background listener task
+        # Background tasks
         self._listener_task: asyncio.Task | None = None
+        self._background_tasks: set[asyncio.Task[Any]] = set()
 
         # Logger
         self.logger = _LOGGER
 
     async def connect(self) -> None:
-        """Connect to the Sony device.
+        """Connect to the Sony device and start the connection manager.
 
         Raises:
             ConnectionError: If connection fails
@@ -87,6 +94,11 @@ class SonyCISIP2:
         if self._connected:
             return
 
+        await self._open_socket()
+        self._start_listener()
+
+    async def _open_socket(self) -> None:
+        """Open the TCP socket without starting the connection manager."""
         try:
             self._reader, self._writer = await asyncio.wait_for(
                 asyncio.open_connection(self.host, self.port),
@@ -96,10 +108,6 @@ class SonyCISIP2:
             await asyncio.sleep(0.1)
             self._connected = True
             self.logger.info("Connected to Sony device at %s:%s", self.host, self.port)
-
-            # Start listening for notifications
-            await self._start_notification_listener()
-
         except TimeoutError as err:
             # TimeoutError subclasses OSError on 3.10+; handle before OSError.
             self._connected = False
@@ -111,17 +119,26 @@ class SonyCISIP2:
             raise ConnectionError(f"Failed to connect: {err}") from err
 
     async def disconnect(self) -> None:
-        """Disconnect from the Sony device."""
+        """Disconnect from the Sony device and stop auto-reconnect."""
         self._listening = False
 
-        # Cancel listener task
         if self._listener_task:
             self._listener_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await self._listener_task
             self._listener_task = None
 
-        # Close connection
+        for task in self._background_tasks:
+            task.cancel()
+        if self._background_tasks:
+            await asyncio.gather(*self._background_tasks, return_exceptions=True)
+        self._background_tasks.clear()
+
+        await self._close_connection()
+        self.logger.info("Disconnected from Sony device")
+
+    async def _close_connection(self) -> None:
+        """Close the socket and fail pending command futures."""
         if self._writer:
             self._writer.close()
             with contextlib.suppress(OSError):
@@ -131,40 +148,30 @@ class SonyCISIP2:
         self._writer = None
         self._connected = False
 
-        # Fail any pending command futures
         for future in self._pending_responses.values():
             if not future.done():
                 future.set_exception(ConnectionError("Disconnected"))
         self._pending_responses.clear()
 
-        self.logger.info("Disconnected from Sony device")
+    async def _mark_disconnected(self) -> None:
+        """Mark connection as lost and clean up."""
+        was_connected = self._connected
+        await self._close_connection()
+        if was_connected:
+            self.logger.warning("Connection to Sony device lost")
 
     async def is_connected(self) -> bool:
-        """Check if connected to the device.
+        """Return whether the client currently has an open connection."""
+        return self._connected
 
-        Returns:
-            True if connected, False otherwise
-        """
-        if not self._connected:
-            return False
-
-        # Try a simple command to verify connection
-        try:
-            await self.get_feature("main.power")
-            return True
-        except Exception:
-            return False
-
-    async def get_feature(self, feature: str) -> Any:
+    async def get_feature(self, feature: str) -> Any | None:
         """Get the value of a feature.
-
-        This is a universal method that works with any CIS-IP2 feature.
 
         Args:
             feature: The feature name (e.g., "main.power", "main.volumestep")
 
         Returns:
-            The feature value, or "Unknown Value" if the request fails
+            The feature value, or ``None`` on timeout, miss, NAK, or ERR
 
         Example:
             >>> power = await client.get_feature("main.power")
@@ -172,20 +179,21 @@ class SonyCISIP2:
         """
         response = await self._send_command(MSG_TYPE_GET, feature)
         if response and response.get("type") == MSG_TYPE_RESULT:
-            return response.get("value", "Unknown Value")
-        return "Unknown Value"
+            value = response.get("value")
+            if value and value not in (RESPONSE_NAK, RESPONSE_ERR):
+                return value
+        return None
 
-    async def set_feature(self, feature: str, value: Any) -> str:
+    async def set_feature(self, feature: str, value: Any) -> str | None:
         """Set a feature to a specific value.
-
-        This is a universal method that works with any CIS-IP2 feature.
 
         Args:
             feature: The feature name (e.g., "main.power", "main.volumestep")
             value: The value to set (can be string, number, etc.)
 
         Returns:
-            "ACK" if successful, "NAK", "ERR", or "Unknown Response" otherwise
+            Device result string (``ACK``, ``NAK``, ``ERR``, …), or ``None``
+            on timeout or miss
 
         Example:
             >>> result = await client.set_feature("main.power", "on")
@@ -193,8 +201,10 @@ class SonyCISIP2:
         """
         response = await self._send_command(MSG_TYPE_SET, feature, value)
         if response and response.get("type") == MSG_TYPE_RESULT:
-            return response.get("value", "Unknown Response")
-        return "Unknown Response"
+            value_out = response.get("value")
+            if value_out is not None:
+                return str(value_out)
+        return None
 
     def register_notification_callback(
         self,
@@ -240,56 +250,74 @@ class SonyCISIP2:
             if not self._notification_callbacks[feature]:
                 del self._notification_callbacks[feature]
 
-    async def _start_notification_listener(self) -> None:
-        """Start the notification listener task."""
+    def _start_listener(self) -> None:
+        """Start the connection manager task if not already running."""
         if self._listener_task and not self._listener_task.done():
             return
 
-        if not self._connected:
-            await self.connect()
+        self._listener_task = asyncio.create_task(self._connection_manager())
 
-        self._listener_task = asyncio.create_task(self._notification_loop())
+    async def _connection_manager(self) -> None:
+        """Run the read loop and reconnect with exponential backoff on drop."""
+        try:
+            while True:
+                await self._notification_loop()
+
+                delay = RECONNECT_INITIAL_DELAY
+                while True:
+                    self.logger.debug("Reconnecting in %ss", delay)
+                    await asyncio.sleep(delay)
+
+                    try:
+                        await self._open_socket()
+                    except (OSError, ConnectionError):
+                        delay = min(delay * 2, RECONNECT_MAX_DELAY)
+                        continue
+
+                    self.logger.info("Reconnected to device")
+                    break
+
+                if self._on_reconnect is not None:
+                    task: asyncio.Task[None] = asyncio.create_task(self._on_reconnect())
+                    self._background_tasks.add(task)
+                    task.add_done_callback(self._background_tasks.discard)
+        except asyncio.CancelledError:
+            self.logger.info("Connection manager cancelled")
+            raise
 
     async def _notification_loop(self) -> None:
-        """Listen for real-time notifications from the device."""
+        """Read and dispatch messages until EOF or a connection error."""
         self._listening = True
         self.logger.info("Starting notification listener")
+        buffer = ""
 
         try:
-            while self._listening and self._connected:
+            while self._connected and self._reader:
                 try:
-                    if not self._reader:
-                        break
-
-                    data = await asyncio.wait_for(self._reader.read(1024), timeout=1.0)
+                    data = await asyncio.wait_for(self._reader.read(8192), timeout=1.0)
 
                     if not data:
-                        await asyncio.sleep(0.1)
-                        continue
+                        self.logger.warning("Connection closed by device (EOF)")
+                        break
 
-                    response_str = data.decode("utf-8", errors="replace").strip()
-                    if not response_str:
-                        continue
-
-                    messages = self._decode_json_stream(response_str)
-                    if not messages:
-                        continue
-
-                    for message in messages:
-                        await self._process_incoming_message(message)
+                    buffer += data.decode("utf-8", errors="replace")
+                    buffer = buffer.strip()
+                    if buffer:
+                        messages, buffer = self._decode_json_stream(buffer)
+                        for message in messages:
+                            await self._process_incoming_message(message)
 
                 except TimeoutError:
                     continue
-                except asyncio.CancelledError:
-                    raise
                 except OSError:
-                    self.logger.exception("Error in notification listener")
-                    await asyncio.sleep(1.0)
+                    self.logger.warning("Connection error in notification listener")
+                    break
         except asyncio.CancelledError:
             self.logger.info("Notification listener cancelled")
             raise
         finally:
             self._listening = False
+            await self._mark_disconnected()
             self.logger.info("Notification listener stopped")
 
     async def _send_command(
@@ -306,30 +334,28 @@ class SonyCISIP2:
             value: Optional value for "set" commands
 
         Returns:
-            The response message, or None on timeout/error
-        """
-        if not self._connected:
-            await self.connect()
+            The response message, or None on timeout
 
-        if not self._writer or not self._reader:
+        Raises:
+            ConnectionError: If not connected or the write fails
+        """
+        if not self._connected or not self._writer or not self._reader:
             raise ConnectionError("Not connected to device")
 
         if not self._listener_task or self._listener_task.done():
-            await self._start_notification_listener()
+            self._start_listener()
 
         response_future: asyncio.Future[dict[str, Any]] | None = None
         command_id: int | None = None
+        command: dict[str, Any] = {
+            "type": message_type,
+            "feature": feature,
+        }
+        if value is not None:
+            command["value"] = value
 
         async with self._command_lock:
             try:
-                # Assign a unique command id
-                command: dict[str, Any] = {
-                    "type": message_type,
-                    "feature": feature,
-                }
-                if value is not None:
-                    command["value"] = value
-
                 command_id = self._get_next_command_id()
                 command["id"] = command_id
 
@@ -342,22 +368,21 @@ class SonyCISIP2:
                 self._writer.write(command_json.encode())
                 await self._writer.drain()
             except OSError as err:
-                if command_id is not None and command_id in self._pending_responses:
+                if command_id is not None:
                     self._pending_responses.pop(command_id, None)
                 self.logger.exception("Error sending command")
                 raise ConnectionError(f"Error sending command: {err}") from err
 
-        try:
-            response = await asyncio.wait_for(response_future, timeout=self.timeout)
-            return response
-        except TimeoutError:
-            if response_future and not response_future.done():
-                response_future.cancel()
-            self.logger.warning("Timeout waiting for response to command: %s", command)
-            return None
-        finally:
-            if command_id is not None:
-                self._pending_responses.pop(command_id, None)
+            try:
+                return await asyncio.wait_for(response_future, timeout=self.timeout)
+            except TimeoutError:
+                self.logger.warning(
+                    "Timeout waiting for response to command: %s", command
+                )
+                return None
+            finally:
+                if command_id is not None:
+                    self._pending_responses.pop(command_id, None)
 
     def _get_next_command_id(self) -> int:
         """Return a unique command id."""
@@ -366,21 +391,22 @@ class SonyCISIP2:
             self._command_id_counter = CMD_ID_INITIAL
         return self._command_id_counter
 
-    def _decode_json_stream(self, data: str) -> list[dict[str, Any]]:
-        """Decode one or more JSON objects from a buffer string.
+    def _decode_json_stream(self, data: str) -> tuple[list[dict[str, Any]], str]:
+        """Decode JSON objects from a buffer, returning unparsed remainder.
 
-        Handles cases where multiple JSON objects arrive in a single read.
+        The device may send concatenated JSON objects with no delimiter.
+        A single TCP read may split an object; the remainder is returned so
+        the caller can prepend it to the next read.
         """
         messages: list[dict[str, Any]] = []
         if not data:
-            return messages
+            return messages, ""
 
         decoder = json.JSONDecoder()
         idx = 0
         length = len(data)
 
         while idx < length:
-            # Skip whitespace between JSON objects
             while idx < length and data[idx].isspace():
                 idx += 1
 
@@ -391,15 +417,10 @@ class SonyCISIP2:
                 message, end = decoder.raw_decode(data, idx)
                 messages.append(message)
                 idx = end
-            except json.JSONDecodeError as err:
-                self.logger.warning(
-                    "Failed to decode JSON chunk: %s (remaining=%s)",
-                    err,
-                    data[idx:],
-                )
-                break
+            except json.JSONDecodeError:
+                return messages, data[idx:]
 
-        return messages
+        return messages, ""
 
     async def _process_incoming_message(self, message: dict[str, Any]) -> None:
         """Process a single incoming message from the device."""
@@ -437,22 +458,20 @@ class SonyCISIP2:
         self, feature: str | None, value: Any
     ) -> None:
         """Invoke registered callbacks for a notification."""
-        # Call feature-specific callbacks
         if feature and feature in self._notification_callbacks:
             for callback in self._notification_callbacks[feature]:
                 try:
-                    if asyncio.iscoroutinefunction(callback):
+                    if inspect.iscoroutinefunction(callback):
                         await callback(feature, value)
                     else:
                         callback(feature, value)
                 except Exception:
                     self.logger.exception("Error in notification callback")
 
-        # Call general callbacks (None key)
         if None in self._notification_callbacks:
             for callback in self._notification_callbacks[None]:
                 try:
-                    if asyncio.iscoroutinefunction(callback):
+                    if inspect.iscoroutinefunction(callback):
                         await callback(feature, value)
                     else:
                         callback(feature, value)

--- a/src/sony_cisip2/constants.py
+++ b/src/sony_cisip2/constants.py
@@ -8,6 +8,10 @@ DEFAULT_PORT = 33336
 # Timeout for TCP operations (in seconds)
 TCP_TIMEOUT = 10.0
 
+# Reconnection delays (seconds); sleep then try; double on failure, capped
+RECONNECT_INITIAL_DELAY = 5.0
+RECONNECT_MAX_DELAY = 60.0
+
 # Command ID management
 CMD_ID_INITIAL = 10
 CMD_ID_MAX = 1_000_000

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,11 +11,20 @@ import pytest
 from sony_cisip2 import SonyCISIP2
 
 
+async def _idle_read(*_args: object, **_kwargs: object) -> bytes:
+    """Block until cancelled so wait_for idle-polls without a busy loop.
+
+    Empty ``b""`` means EOF and must not be the default return value.
+    """
+    await asyncio.sleep(3600)
+    return b""
+
+
 @pytest.fixture
 def mock_reader() -> AsyncMock:
-    """Create a mock StreamReader."""
+    """Create a mock StreamReader that idles until cancelled."""
     reader = AsyncMock()
-    reader.read = AsyncMock(return_value=b"")
+    reader.read = AsyncMock(side_effect=_idle_read)
     return reader
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -61,6 +61,8 @@ async def test_connect_success(mock_connection):
         assert client._writer == mock_writer
         mock_open.assert_called_once_with("192.168.1.100", DEFAULT_PORT)
 
+        await client.disconnect()
+
 
 @pytest.mark.asyncio
 async def test_connect_failure():
@@ -123,7 +125,6 @@ async def test_disconnect_with_listener_task(mock_connection):
         mock_open.return_value = (mock_reader, mock_writer)
 
         await client.connect()
-        await client._start_notification_listener()
 
         assert client._listener_task is not None
 
@@ -225,9 +226,7 @@ async def test_command_timeout(mock_connection):
         with patch.object(client, "_get_next_command_id", return_value=13):
             result = await client.get_feature("main.power")
 
-        # Should return "Unknown Value" on timeout
-        assert result == "Unknown Value"
-        # Future should be cancelled/cleaned up
+        assert result is None
         assert 13 not in client._pending_responses
 
 
@@ -328,12 +327,13 @@ async def test_json_stream_decoding():
         '{"id":2,"type":"result","value":"50"}'
     )
 
-    messages = client._decode_json_stream(json_stream)
+    messages, remainder = client._decode_json_stream(json_stream)
 
     assert len(messages) == 3
     assert messages[0]["id"] == 1
     assert messages[1]["type"] == "notify"
     assert messages[2]["value"] == "50"
+    assert remainder == ""
 
 
 @pytest.mark.asyncio
@@ -343,25 +343,40 @@ async def test_json_stream_decoding_whitespace():
 
     json_stream = '   {"id":1,"type":"result"}   \n\n   {"id":2,"type":"result"}   '
 
-    messages = client._decode_json_stream(json_stream)
+    messages, remainder = client._decode_json_stream(json_stream)
 
     assert len(messages) == 2
     assert messages[0]["id"] == 1
     assert messages[1]["id"] == 2
+    assert remainder == ""
+
+
+@pytest.mark.asyncio
+async def test_json_stream_decoding_incomplete_remainder():
+    """Incomplete trailing JSON is returned as remainder, not dropped."""
+    client = SonyCISIP2(host="192.168.1.100", timeout=1.0)
+
+    json_stream = '{"id":1,"type":"result"}{"id":2,"type":"res'
+
+    messages, remainder = client._decode_json_stream(json_stream)
+
+    assert len(messages) == 1
+    assert messages[0]["id"] == 1
+    assert remainder == '{"id":2,"type":"res'
 
 
 @pytest.mark.asyncio
 async def test_json_stream_decoding_invalid():
-    """Test JSON stream decoding with invalid JSON."""
+    """Test JSON stream decoding with invalid JSON after a complete object."""
     client = SonyCISIP2(host="192.168.1.100", timeout=1.0)
 
     json_stream = '{"id":1,"type":"result"}{invalid json}'
 
-    messages = client._decode_json_stream(json_stream)
+    messages, remainder = client._decode_json_stream(json_stream)
 
-    # Should decode the first valid JSON and stop at invalid
     assert len(messages) == 1
     assert messages[0]["id"] == 1
+    assert remainder == "{invalid json}"
 
 
 @pytest.mark.asyncio
@@ -404,23 +419,18 @@ async def test_is_connected_not_connected():
 
 @pytest.mark.asyncio
 async def test_is_connected_success(mock_connection):
-    """Test is_connected when connected."""
+    """Test is_connected reflects the connection flag."""
     mock_reader, mock_writer = mock_connection
     client = SonyCISIP2(host="192.168.1.100", timeout=1.0)
-
-    response = {"id": 10, "type": "result", "feature": "main.power", "value": "on"}
 
     with patch("asyncio.open_connection", new_callable=AsyncMock) as mock_open:
         mock_open.return_value = (mock_reader, mock_writer)
 
         await client.connect()
+        assert await client.is_connected()
 
-        asyncio.create_task(_resolve_pending(client, 10, response))
-
-        with patch.object(client, "_get_next_command_id", return_value=10):
-            result = await client.is_connected()
-
-        assert result
+        await client.disconnect()
+        assert not await client.is_connected()
 
 
 @pytest.mark.asyncio
@@ -481,3 +491,53 @@ async def test_connect_when_already_connected(mock_connection):
         call_count = mock_open.call_count
         await client.connect()
         assert mock_open.call_count == call_count  # No new call
+
+
+@pytest.mark.asyncio
+async def test_get_feature_nak_returns_none(mock_connection):
+    """NAK / ERR / empty get values become None."""
+    mock_reader, mock_writer = mock_connection
+    client = SonyCISIP2(host="192.168.1.100", timeout=1.0)
+
+    with patch("asyncio.open_connection", new_callable=AsyncMock) as mock_open:
+        mock_open.return_value = (mock_reader, mock_writer)
+        await client.connect()
+
+        for value, cmd_id in (("NAK", 20), ("ERR", 21), ("", 22)):
+            response = {
+                "id": cmd_id,
+                "type": "result",
+                "feature": "main.power",
+                "value": value,
+            }
+            asyncio.create_task(_resolve_pending(client, cmd_id, response))
+            with patch.object(client, "_get_next_command_id", return_value=cmd_id):
+                assert await client.get_feature("main.power") is None
+
+        await client.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_set_feature_timeout_returns_none(mock_connection):
+    """set_feature returns None on timeout."""
+    mock_reader, mock_writer = mock_connection
+    client = SonyCISIP2(host="192.168.1.100", timeout=0.1)
+
+    with patch("asyncio.open_connection", new_callable=AsyncMock) as mock_open:
+        mock_open.return_value = (mock_reader, mock_writer)
+        await client.connect()
+
+        with patch.object(client, "_get_next_command_id", return_value=30):
+            result = await client.set_feature("main.power", "on")
+
+        assert result is None
+        await client.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_send_while_disconnected_raises():
+    """Commands raise immediately when not connected."""
+    client = SonyCISIP2(host="192.168.1.100", timeout=1.0)
+
+    with pytest.raises(ConnectionError, match="Not connected"):
+        await client.get_feature("main.power")

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -14,6 +14,13 @@ def test_tcp_timeout():
     assert isinstance(constants.TCP_TIMEOUT, float)
 
 
+def test_reconnect_delays():
+    """Test reconnect backoff constants."""
+    assert constants.RECONNECT_INITIAL_DELAY == 5.0
+    assert constants.RECONNECT_MAX_DELAY == 60.0
+    assert constants.RECONNECT_MAX_DELAY > constants.RECONNECT_INITIAL_DELAY
+
+
 def test_command_id_initial():
     """Test command ID initial value."""
     assert constants.CMD_ID_INITIAL == 10

--- a/tests/test_reconnect.py
+++ b/tests/test_reconnect.py
@@ -1,0 +1,235 @@
+"""Tests for disconnect cleanup, stream buffering, and reconnect."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from sony_cisip2 import SonyCISIP2
+from sony_cisip2.constants import RECONNECT_INITIAL_DELAY, RECONNECT_MAX_DELAY
+
+
+def _setup_connected_stream(client: SonyCISIP2) -> AsyncMock:
+    """Attach mock reader/writer and mark connected (no live manager)."""
+    mock_reader = AsyncMock()
+    mock_writer = MagicMock()
+    mock_writer.close = MagicMock()
+    mock_writer.wait_closed = AsyncMock()
+    client._reader = mock_reader
+    client._writer = mock_writer
+    client._connected = True
+    return mock_reader
+
+
+@pytest.mark.asyncio
+async def test_mark_disconnected_fails_pending_commands() -> None:
+    """Pending futures fail with ConnectionError on mark-disconnected."""
+    client = SonyCISIP2(host="192.168.1.100", timeout=1.0)
+    client._connected = True
+
+    loop = asyncio.get_running_loop()
+    future = loop.create_future()
+    client._pending_responses[42] = future
+
+    await client._mark_disconnected()
+
+    assert not client._connected
+    assert future.done()
+    with pytest.raises(ConnectionError, match="Disconnected"):
+        future.result()
+
+
+@pytest.mark.asyncio
+async def test_notification_loop_exits_on_eof() -> None:
+    """Empty read is EOF: loop exits and clears connected."""
+    client = SonyCISIP2(host="192.168.1.100", timeout=1.0)
+    mock_reader = _setup_connected_stream(client)
+    mock_reader.read = AsyncMock(return_value=b"")
+
+    loop = asyncio.get_running_loop()
+    future = loop.create_future()
+    client._pending_responses[7] = future
+
+    await client._notification_loop()
+
+    assert not client._connected
+    with pytest.raises(ConnectionError, match="Disconnected"):
+        future.result()
+
+
+@pytest.mark.asyncio
+async def test_notification_loop_exits_on_os_error() -> None:
+    """OSError in the read loop marks disconnected and fails pendings."""
+    client = SonyCISIP2(host="192.168.1.100", timeout=1.0)
+    mock_reader = _setup_connected_stream(client)
+    mock_reader.read = AsyncMock(side_effect=OSError("Connection reset"))
+
+    loop = asyncio.get_running_loop()
+    future = loop.create_future()
+    client._pending_responses[8] = future
+
+    await client._notification_loop()
+
+    assert not client._connected
+    with pytest.raises(ConnectionError, match="Disconnected"):
+        future.result()
+
+
+@pytest.mark.asyncio
+async def test_fragmented_json_across_reads() -> None:
+    """Split JSON object across two reads is reconstituted."""
+    client = SonyCISIP2(host="192.168.1.100", timeout=1.0)
+    mock_reader = _setup_connected_stream(client)
+
+    part1 = b'{"id":1,"type":"result","value":"o'
+    part2 = b'n"}'
+    reads = iter([part1, part2, b""])
+    mock_reader.read = AsyncMock(side_effect=lambda *_a, **_k: next(reads))
+
+    processed: list[dict] = []
+
+    async def _capture(message: dict) -> None:
+        processed.append(message)
+
+    with patch.object(client, "_process_incoming_message", side_effect=_capture):
+        await client._notification_loop()
+
+    assert processed == [{"id": 1, "type": "result", "value": "on"}]
+    assert not client._connected
+
+
+@pytest.mark.asyncio
+async def test_burst_chunked_json_loses_no_messages() -> None:
+    """Many messages chunked across small reads are all processed."""
+    client = SonyCISIP2(host="192.168.1.100", timeout=1.0)
+    mock_reader = _setup_connected_stream(client)
+
+    messages = [{"id": i, "type": "result", "value": "ACK"} for i in range(1, 21)]
+    blob = "".join(json.dumps(m) for m in messages).encode()
+    chunk_size = 80
+    chunks = [blob[i : i + chunk_size] for i in range(0, len(blob), chunk_size)]
+    chunks.append(b"")
+    reads = iter(chunks)
+    mock_reader.read = AsyncMock(side_effect=lambda *_a, **_k: next(reads))
+
+    processed: list[dict] = []
+
+    async def _capture(message: dict) -> None:
+        processed.append(message)
+
+    with patch.object(client, "_process_incoming_message", side_effect=_capture):
+        await client._notification_loop()
+
+    assert processed == messages
+
+
+@pytest.mark.asyncio
+async def test_disconnect_cancels_manager_no_reconnect(
+    mock_connection: tuple[AsyncMock, MagicMock],
+) -> None:
+    """Explicit disconnect cancels the manager; no reconnect open attempts."""
+    mock_reader, mock_writer = mock_connection
+    client = SonyCISIP2(host="192.168.1.100", timeout=1.0)
+
+    with patch("asyncio.open_connection", new_callable=AsyncMock) as mock_open:
+        mock_open.return_value = (mock_reader, mock_writer)
+        await client.connect()
+        assert client._listener_task is not None
+        connect_calls = mock_open.call_count
+
+        await client.disconnect()
+
+        assert client._listener_task is None
+        assert not client._connected
+        await asyncio.sleep(0.05)
+        assert mock_open.call_count == connect_calls
+
+
+@pytest.mark.asyncio
+async def test_connection_manager_exponential_backoff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reconnect sleeps use 5, 10, 20, … capped at max."""
+    client = SonyCISIP2(host="192.168.1.100", timeout=1.0)
+
+    sleep_delays: list[float] = []
+    max_failures = 5
+    open_attempts = 0
+    loop_count = 0
+
+    async def _one_shot_loop() -> None:
+        nonlocal loop_count
+        loop_count += 1
+        if loop_count > 1:
+            raise asyncio.CancelledError
+        client._connected = False
+
+    async def _fake_sleep(delay: float) -> None:
+        sleep_delays.append(delay)
+
+    async def _fail_then_succeed() -> None:
+        nonlocal open_attempts
+        open_attempts += 1
+        if open_attempts <= max_failures:
+            raise ConnectionError("refused")
+        client._connected = True
+
+    monkeypatch.setattr(client, "_notification_loop", _one_shot_loop)
+    monkeypatch.setattr(asyncio, "sleep", _fake_sleep)
+    monkeypatch.setattr(client, "_open_socket", _fail_then_succeed)
+
+    with pytest.raises(asyncio.CancelledError):
+        await client._connection_manager()
+
+    assert sleep_delays[0] == RECONNECT_INITIAL_DELAY
+    for i in range(1, max_failures):
+        expected = min(RECONNECT_INITIAL_DELAY * (2**i), RECONNECT_MAX_DELAY)
+        assert sleep_delays[i] == expected
+
+
+@pytest.mark.asyncio
+async def test_reconnect_schedules_on_reconnect_hook(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """on_reconnect is scheduled after reconnect, not awaited inline."""
+    hook_started = asyncio.Event()
+    hook_finished = asyncio.Event()
+    second_loop_entered = asyncio.Event()
+
+    async def _slow_hook() -> None:
+        hook_started.set()
+        await hook_finished.wait()
+
+    client = SonyCISIP2(host="192.168.1.100", timeout=1.0, on_reconnect=_slow_hook)
+
+    loop_count = 0
+
+    async def _two_loops() -> None:
+        nonlocal loop_count
+        loop_count += 1
+        if loop_count == 1:
+            client._connected = False
+            return
+        second_loop_entered.set()
+        await asyncio.Future()
+
+    async def _succeed_open() -> None:
+        client._connected = True
+
+    monkeypatch.setattr(client, "_notification_loop", _two_loops)
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+    monkeypatch.setattr(client, "_open_socket", _succeed_open)
+
+    manager_task = asyncio.create_task(client._connection_manager())
+
+    await asyncio.wait_for(hook_started.wait(), timeout=1.0)
+    assert not hook_finished.is_set()
+    await asyncio.wait_for(second_loop_entered.wait(), timeout=1.0)
+
+    hook_finished.set()
+    manager_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await manager_task

--- a/tools/live_smoke.py
+++ b/tools/live_smoke.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Live smoke: connect → get power → notify wait → optional volume read-back.
+
+Env:
+  CISIP2_HOST       device IP (required)
+  CISIP2_PORT       TCP port (default 33336)
+  CISIP2_SKIP_EXEC  set to 1 to skip volume write (connect + get only)
+
+Exit 0 on success, 1 on failure, 2 if required env is missing.
+
+Not run in CI. Does not import homeassistant.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+from sony_cisip2 import SonyCISIP2
+from sony_cisip2.constants import DEFAULT_PORT
+
+
+async def _run(host: str, port: int, *, skip_exec: bool) -> int:
+    notifies: list[tuple[str | None, object]] = []
+
+    def on_notify(feature: str | None, value: object) -> None:
+        notifies.append((feature, value))
+        print(f"notify {feature}={value!r}")
+
+    client = SonyCISIP2(host=host, port=port)
+    print(f"connecting {host}:{port} …")
+    await client.connect()
+    try:
+        client.register_notification_callback(None, on_notify)
+
+        power = await client.get_feature("main.power")
+        print(f"main.power={power!r}")
+        if power is None:
+            print("FAIL: get main.power returned None", file=sys.stderr)
+            return 1
+
+        # Brief window for any notify traffic (none expected without UI changes).
+        await asyncio.sleep(1.0)
+        print(f"notifies_seen={len(notifies)}")
+
+        if skip_exec:
+            print("done (connect + get; exec skipped)")
+            return 0
+
+        if power != "on":
+            print("power is not on; skipping volume exec")
+            print("done (connect + get; volume exec skipped)")
+            return 0
+
+        before = await client.get_feature("main.volumestep")
+        print(f"main.volumestep before={before!r}")
+        if before is None:
+            print("FAIL: get main.volumestep returned None", file=sys.stderr)
+            return 1
+
+        try:
+            before_int = int(before)
+        except (TypeError, ValueError):
+            print(f"FAIL: volumestep not an int: {before!r}", file=sys.stderr)
+            return 1
+
+        target = before_int + 1 if before_int < 50 else before_int - 1
+        result = await client.set_feature("main.volumestep", target)
+        print(f"set main.volumestep={target} → {result!r}")
+        if result != "ACK":
+            print(f"FAIL: expected ACK, got {result!r}", file=sys.stderr)
+            return 1
+
+        await asyncio.sleep(0.5)
+        after = await client.get_feature("main.volumestep")
+        print(f"main.volumestep after={after!r}")
+        if after is None or int(after) != target:
+            print(
+                f"FAIL: expected volumestep={target}, got {after!r}",
+                file=sys.stderr,
+            )
+            return 1
+
+        restore = await client.set_feature("main.volumestep", before_int)
+        print(f"restore main.volumestep={before_int} → {restore!r}")
+
+        print("done (volume change confirmed)")
+        return 0
+    finally:
+        await client.disconnect()
+
+
+def main() -> int:
+    host = os.environ.get("CISIP2_HOST")
+    if not host:
+        print("Set CISIP2_HOST", file=sys.stderr)
+        return 2
+
+    port = int(os.environ.get("CISIP2_PORT", str(DEFAULT_PORT)))
+    skip_exec = os.environ.get("CISIP2_SKIP_EXEC") == "1"
+    return asyncio.run(_run(host, port, skip_exec=skip_exec))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What does this implement/fix?

Hardens the `SonyCISIP2` TCP client for reliable local control: 
- JSON stream decode keeps an unparsed remainder across reads
- unexpected EOF/OSError fails pending commands and clears the connection
- connection manager reconnects with exponential backoff. 

Also...
- `get_feature` / `set_feature` return `None` on timeout or miss instead of string sentinels. 
- Adds `tools/live_smoke.py` (`CISIP2_HOST`) for optional device checks (not in CI).

Version stays `0.1.0a0` (no PyPI publish in this PR).

## Types of changes

- [ ] Bugfix — `bugfix`
- [ ] New feature — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`
- [ ] Skip changelog — `skip-changelog`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pytest -q` passes, and tests have been added/updated under `tests/` where applicable.
- [x] `ruff check . && ruff format --check .` and `mypy` pass.
- [x] `python -m build && twine check dist/*` when packaging/metadata changed.

## Test plan

- [x] `pytest -q` (includes stream fragmentation, disconnect cleanup, reconnect backoff)
- [x] Live smoke on HT-A9M2 at `10.0.110.130`:
  - `CISIP2_HOST=… CISIP2_SKIP_EXEC=1 python tools/live_smoke.py` → `main.power=on`
  - Full smoke → volumestep bump ACK + notify + restore
- [x] `python -m build && twine check dist/*` → `sony_cisip2-0.1.0a0` sdist/wheel PASSED