### PR TITLE
Ignore uv.lock for library installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/
 dist/
 .venv/
 venv/
+uv.lock
 
 # misc
 .coverage


### PR DESCRIPTION
## What does this implement/fix?

Adds `uv.lock` to `.gitignore`. This is a PyPI library; consumers and CI resolve from `pyproject.toml`, and local `uv run` should not leave an untracked lockfile in `git status`.

## Types of changes

- [ ] Bugfix — `bugfix`
- [ ] New feature — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`
- [x] Skip changelog — `skip-changelog`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pytest -q` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] `ruff check . && ruff format --check .` and `mypy` pass.
- [ ] `python -m build && twine check dist/*` when packaging/metadata changed.

## Test plan

- [x] Confirm `uv.lock` is ignored (`git check-ignore -v uv.lock`)


Made with [Cursor](https://cursor.com)