### PR TITLE
Release sony-cisip2 0.1.0a1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0a1] - 2026-07-26
+
 ### Added
 
 - Hatchling packaging as PyPI name `sony-cisip2` (import `sony_cisip2`).
-- `src/` layout, `__version__ = "0.1.0a0"`, CI (lint/mypy/pytest matrix/build),
-  and tag-based Publish workflow with Trusted Publishing.
+- `src/` layout, initial `__version__` / Hatch packaging, CI
+  (lint/mypy/pytest matrix/build), and tag-based Publish workflow with
+  Trusted Publishing.
 - Changelog, releasing docs, and agent/PR templates mirrored from sibling
   packaging practices.
 - Auto-reconnect with exponential backoff after unexpected TCP drops
@@ -35,3 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Empty TCP read (EOF) and listener `OSError` mark the client disconnected and
   fail pending command futures.
+
+[Unreleased]: https://github.com/steamEngineer/sony-cispy/compare/v0.1.0a1...HEAD
+[0.1.0a1]: https://github.com/steamEngineer/sony-cispy/releases/tag/v0.1.0a1

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ that speak CIS-IP2 can depend on this package.
 
 ## Status
 
-**Alpha** (`0.1.0a0` in-tree; first PyPI publish planned as `0.1.0a1`). APIs may
-change before 1.0. See [CHANGELOG.md](CHANGELOG.md).
+**Alpha** (`0.1.0a1` on PyPI). APIs may change before 1.0. See
+[CHANGELOG.md](CHANGELOG.md).
 
 ## Features
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -12,13 +12,14 @@
    uploads `sony-cisip2` to PyPI via Trusted Publishing, and creates a GitHub
    Release from the matching changelog section.
 
-The first PyPI publish is planned as **`0.1.0a1`** (tag `v0.1.0a1`). In-tree
-`0.1.0a0` is a packaging placeholder and is not intended for a tag.
+First PyPI release was **`0.1.0a1`** (tag `v0.1.0a1`). Do not tag placeholder
+versions that were never intended for publish.
 
 ## One-time: PyPI Trusted Publisher
 
 Before the first tag that should upload to PyPI, add a **pending Trusted
-Publisher** on PyPI for project **`sony-cisip2`**:
+Publisher** on PyPI for project **`sony-cisip2`** (already done for this
+repo):
 
 | Field | Value |
 |-------|--------|
@@ -27,4 +28,5 @@ Publisher** on PyPI for project **`sony-cisip2`**:
 | Workflow | `publish.yml` |
 | Environment | `pypi` |
 
+Also ensure a GitHub Actions Environment named `pypi` exists on the repo.
 The first successful tagged Publish run creates the PyPI project.

--- a/src/sony_cisip2/__init__.py
+++ b/src/sony_cisip2/__init__.py
@@ -8,5 +8,5 @@ from .client import SonyCISIP2
 from .commandset import commands_dict
 from .variables import variables_dict
 
-__version__ = "0.1.0a0"
+__version__ = "0.1.0a1"
 __all__ = ["SonyCISIP2", "commands_dict", "variables_dict", "__version__"]


### PR DESCRIPTION
## What does this implement/fix?

Bump `__version__` to `0.1.0a1`, promote CHANGELOG for the first PyPI alpha, and refresh Status/releasing docs. Tag `v0.1.0a1` follows merge so Trusted Publishing can upload `sony-cisip2`.

## Types of changes

- [x] Maintenance / chore — `maintenance`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pytest -q` passes, and tests have been added/updated under `tests/` where applicable.
- [x] `ruff check . && ruff format --check .` and `mypy` pass.
- [ ] `python -m build && twine check dist/*` when packaging/metadata changed.

## Test plan

- [x] `from sony_cisip2 import __version__` asserts `0.1.0a1`
- [x] `pytest -q` (54 passed)
- [ ] After merge: tag `v0.1.0a1`, confirm Publish workflow → PyPI + GitHub Release
- [ ] Clean venv: `pip install sony-cisip2==0.1.0a1`


Made with [Cursor](https://cursor.com)