### PR TITLE
Credit Willem-Jan van Rootselaar in LICENSE and README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2025 steamEngineer (Ryan Ludwig)
+Copyright (c) 2025-2026 steamEngineer (Ryan Ludwig)
+Copyright (c) 2025-2026 Willem-Jan van Rootselaar
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
-Copyright (c) 2025-2026 steamEngineer (Ryan Ludwig)
-Copyright (c) 2025-2026 Willem-Jan van Rootselaar
+Copyright (c) 2025-2026 Ryan Ludwig (steamEngineer)
+Copyright (c) 2025-2026 Willem-Jan van Rootselaar (liudger)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -121,9 +121,13 @@ CISIP2_HOST=<device-ip> python tools/live_smoke.py
 
 Release process: [docs/releasing.md](docs/releasing.md).
 
+## Credits
+
+- [@liudger](https://github.com/liudger) (Willem-Jan van Rootselaar) — substantial CIS-IP2 client work in [bravia-quad-homeassistant](https://github.com/steamEngineer/bravia-quad-homeassistant) (reconnect/availability, notifications, volume transitions, and related TCP control paths) that this library was extracted from
+
 ## License
 
-MIT — see [LICENSE](LICENSE).
+MIT — see [LICENSE](LICENSE). Copyright holders are listed in [LICENSE](LICENSE).
 
 ## Disclaimer
 


### PR DESCRIPTION
## What does this implement/fix?

Adds [@liudger](https://github.com/liudger) (Willem-Jan van Rootselaar) as a copyright holder in `LICENSE` and a Credits section in the README for substantial CIS-IP2 client work in bravia-quad-homeassistant that this library was extracted from.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix — `bugfix`
- [ ] New feature — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`
- [ ] Skip changelog — `skip-changelog`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pytest -q` passes, and tests have been added/updated under `tests/` where applicable.
- [x] `ruff check . && ruff format --check .` and `mypy` pass.
- [x] `python -m build && twine check dist/*` when packaging/metadata changed.

## Test plan

- [x] Review `LICENSE` copyright lines and README Credits for accuracy
- [x] Docs-only — no runtime behaviour change

Made with [Cursor](https://cursor.com)